### PR TITLE
(refactor) Move startInStage() from Flow to FlowHandler to simplify testing.

### DIFF
--- a/modules/flow/src/main/java/io/datafx/controller/flow/Flow.java
+++ b/modules/flow/src/main/java/io/datafx/controller/flow/Flow.java
@@ -385,23 +385,7 @@ public class Flow {
      * @throws FlowException If the flow can't be created or started
      */
     public void startInStage(Stage stage) throws FlowException {
-        FlowHandler handler = createHandler();
-        stage.setScene(new Scene(handler.start(new DefaultFlowContainer())));
-        handler.getCurrentViewMetadata().addListener((e) -> {
-            stage.titleProperty().unbind();
-            ViewMetadata metadata = handler.getCurrentViewMetadata().get();
-            if (metadata != null) {
-                stage.titleProperty().bind(metadata.titleProperty());
-            }
-        });
-
-        stage.titleProperty().unbind();
-        ViewMetadata metadata = handler.getCurrentViewMetadata().get();
-        if (metadata != null) {
-            stage.titleProperty().bind(metadata.titleProperty());
-        }
-
-        stage.show();
+        createHandler().startInStage(stage, new DefaultFlowContainer());
     }
 
     public void startInPane(StackPane pane) throws FlowException {

--- a/modules/flow/src/main/java/io/datafx/controller/flow/FlowHandler.java
+++ b/modules/flow/src/main/java/io/datafx/controller/flow/FlowHandler.java
@@ -39,11 +39,15 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
 import io.datafx.controller.FxmlLoadException;
 import io.datafx.controller.ViewConfiguration;
 import io.datafx.controller.ViewFactory;
@@ -105,6 +109,29 @@ public class FlowHandler {
 
     public void startInPane(StackPane pane) throws FlowException {
         start(new DefaultFlowContainer(pane));
+    }
+
+    public void startInStage(Stage stage) throws FlowException {
+        startInStage(stage, new DefaultFlowContainer());
+    }
+
+    public <T extends Parent> void startInStage(Stage stage, FlowContainer<T> container) throws FlowException {
+        stage.setScene(new Scene(start(container)));
+        getCurrentViewMetadata().addListener((e) -> {
+            stage.titleProperty().unbind();
+            ViewMetadata metadata = getCurrentViewMetadata().get();
+            if (metadata != null) {
+                stage.titleProperty().bind(metadata.titleProperty());
+            }
+        });
+
+        stage.titleProperty().unbind();
+        ViewMetadata metadata = getCurrentViewMetadata().get();
+        if (metadata != null) {
+            stage.titleProperty().bind(metadata.titleProperty());
+        }
+
+        stage.show();
     }
 
     public Tab startInTab() throws FlowException {


### PR DESCRIPTION
This simplifies testing of DataFX controllers a bit as the example below shows. Previously we had no possibility to use `startInStage()` and fetch the `FlowHandler` which was used in this method.

Note: `<T extends Parent>` in `void startInStage(Stage stage, FlowContainer<T> container)`, because `Scene`'s constructor requires a `Parent`.

This is based on an issue at https://github.com/TestFX/TestFX/issues/207.

~~~java
@Override
public void start(Stage stage) throws Exception {
    Flow flow = new Flow(ManageCtrl.class);

    FlowHandler handler = flow.createHandler();
    handler.startInStage(stage);

    FlowView view = handler.getCurrentView();
    controller = (ManageCtrl) view.getViewContext().getController();
}
~~~

The complete example is here: https://gist.github.com/hastebrot/0d56eae0cae9e76c481b

Please let me know if something needs to be changed in this PR.

