### PR TITLE
Replace @FXMLController with @ViewController

### DIFF
--- a/flow/src/main/java/io/datafx/controller/ViewController.java
+++ b/flow/src/main/java/io/datafx/controller/ViewController.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2011, 2014, Jonathan Giles, Johan Vos, Hendrik Ebbers All
  * rights reserved.
- *
+ * <p>
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met: *
  * Redistributions of source code must retain the above copyright notice, this
@@ -12,7 +12,7 @@
  * javafxdata.org, nor the names of its contributors may be used to endorse or
  * promote products derived from this software without specific prior written
  * permission.
- *
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -35,15 +35,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>
  * Annotation for a MVC controller. This annotation will define the view (FXML file or java class)
- * this controller is made for. You don't need to use this annotation because
- * the API is designed using a convention over configuration approach: If you
- * have a fxml file "master.fxml" you can create a MasterController.java
+ * this controller is made for.
+ * <p>
+ * You don't <i>need</i> to use this annotation—the API is designed
+ * using a convention over configuration approach: If you
+ * have an fxml file "master.fxml" you can create a MasterController.java
  * controller in the same package and the controller API will use this
  * controller for the fxml. To create a controller/view pair you need to use the
  * {@link ViewFactory}.
- * </p>
  * <p>
  * An example of a simple controller:
  * </p>

--- a/flow/src/main/java/io/datafx/controller/ViewFactory.java
+++ b/flow/src/main/java/io/datafx/controller/ViewFactory.java
@@ -81,11 +81,14 @@ public class ViewFactory {
     /**
      * Creates a new MVC based view by using the given controller class. The
      * class needs a default constructor (no parameters) and a
-     * {@link ViewController} annotation to link to the fxml file. You can skip
-     * the annotation if you want to use the controller API conventions. By
-     * doing so the fxml files has to be in the package as the controller and
+     * {@link ViewController} annotation to link to the fxml file.
+     * <p>
+     * You can skip the annotation if you want to use the controller API conventions.
+     * In order to do so, the fxml file has to be in the same package as the controller and
      * must fit to a naming convention (see {@link ViewController} for more
-     * informations). The method returns a {@link io.datafx.controller.context.ViewContext}. This is a
+     * information).
+     * <p>
+     * The method returns a {@link io.datafx.controller.context.ViewContext}. This is a
      * wrapper around the view (view-node and controller) and can be used to
      * register your datamodel to the view. The doc of {@link io.datafx.controller.context.ViewContext} will
      * provide more information about this topic.

--- a/flow/src/main/java/io/datafx/controller/flow/Flow.java
+++ b/flow/src/main/java/io/datafx/controller/flow/Flow.java
@@ -364,7 +364,7 @@ public class Flow {
      * Starts the flow directly in a Stage. This method is useful if an application contains of one main flow. Because
      * this flow can contain several sub-flows this is the preferred way to create a DataFX based application. The title
      * of the Stage will be bound to the title of the flow metadata and will change whenever the flow title fill change.
-     * This can happen if a view of the flow defines its own title by using the title attribute of the @FXMLController
+     * This can happen if a view of the flow defines its own title by using the title attribute of the @ViewController
      * annotation or the ViewMetadata of an view is changed in code.
      * <p>
      * By using the method a flow based application can be created by only a few lines of code as shown in this example:

--- a/tutorials/flow1/src/main/java/io/datafx/tutorial/SimpleController.java
+++ b/tutorials/flow1/src/main/java/io/datafx/tutorial/SimpleController.java
@@ -37,7 +37,7 @@ import javax.annotation.PostConstruct;
 
 /**
  * This is the controller class for the view used in this first tutorial. 
- * By using the DataFX @FXMLController annotation
+ * By using the DataFX @ViewController annotation
  * the class defines its FXML file that contains the layout of the view and defines its UI components.
  * By using the JavaFX @FXML annotation that is part of the basic JavaFX API, components that are defined in the FXML file can be easily
  * injected in the controller. Once the controller is created the init() methods will be called by the Flow Framework. 

--- a/tutorials/flow1/src/main/java/io/datafx/tutorial/Tutorial1Main.java
+++ b/tutorials/flow1/src/main/java/io/datafx/tutorial/Tutorial1Main.java
@@ -46,7 +46,7 @@ public class Tutorial1Main extends Application {
     public void start(Stage primaryStage) throws Exception {
         // This is the most simple way to start a flow:
         // The Controller class of the start view is always passed as parameter to the constructor of the Flow class.
-        // The Controller class should be annotated with @FXMLController
+        // The Controller class should be annotated with @ViewController
         
         // The Flow class provides a utility method (startInStage) that renders the Flow in a Stage. By doing so the Scene will be created
         // automatically and the Stage will contain a Scene that only contains the flow.

--- a/tutorials/flow2/src/main/java/io/datafx/tutorial/View1Controller.java
+++ b/tutorials/flow2/src/main/java/io/datafx/tutorial/View1Controller.java
@@ -7,7 +7,7 @@ import io.datafx.controller.flow.action.LinkAction;
 
 /**
  * <p>
- * This class defines the controller for the first view of this example. The @FXMLController annotation defines that the
+ * This class defines the controller for the first view of this example. The @ViewController annotation defines that the
  * view1.fxml file contains the definition of the UI of this view.
  * As described in the Tutorial2Main class this example will show how you can navigate between several views in flow. In
  * this example there are only two views that are defined by its controller classes: View1Controller and View2Controller.

--- a/tutorials/flow2/src/main/java/io/datafx/tutorial/View2Controller.java
+++ b/tutorials/flow2/src/main/java/io/datafx/tutorial/View2Controller.java
@@ -7,7 +7,7 @@ import io.datafx.controller.flow.action.LinkAction;
 
 /**
  * <p>
- * This class defines the controller for the second view of this example. The @FXMLController annotation defines that the
+ * This class defines the controller for the second view of this example. The @ViewController annotation defines that the
  * view2.fxml file contains the definition of the UI of this view.
  * As described in the Tutorial2Main class this example will show how you can navigate between several views in flow. In
  * this example there are only two views that are defined by its controller classes: View1Controller and View2Controller.

--- a/tutorials/flow3/src/main/java/io/datafx/tutorial/Wizard1Controller.java
+++ b/tutorials/flow3/src/main/java/io/datafx/tutorial/Wizard1Controller.java
@@ -11,7 +11,7 @@ import io.datafx.controller.flow.action.LinkAction;
  * define the "next" button. By using the @LinkAction annotation this button will link on the next step of the
  * wizard. This annotation was already described in tutorial 2.
  *
- * When looking at the @FXMLController annotation of the class you can find a new feature. Next to the fxml files that
+ * When looking at the @ViewController annotation of the class you can find a new feature. Next to the fxml files that
  * defines the view of the wizard step a "title" is added. This defines the title of the view. Because the wizard is
  * added to a Stage by using the Flow.startInStage() method, the window title of the Stage is automatically bound to
  * the title of the flow. So whenever the view in the flow changes the title of the application window will change to

--- a/tutorials/flow3/src/main/java/io/datafx/tutorial/Wizard2Controller.java
+++ b/tutorials/flow3/src/main/java/io/datafx/tutorial/Wizard2Controller.java
@@ -11,7 +11,7 @@ import io.datafx.controller.flow.action.LinkAction;
  * define the "next" button. By using the @LinkAction annotation this button will link on the next step of the
  * wizard. This annotation was already described in tutorial 2.
  *
- * When looking at the @FXMLController annotation of the class you can find a new feature. next to the fxml files that
+ * When looking at the @ViewController annotation of the class you can find a new feature. next to the fxml files that
  * defines the view of the wizard step a "title" is added. This defines the title of the view. Because the wizard is
  * added to a Stage by using the Flow.startInStage() method the title of the flow is automatically bound to the window
  * title of the Stage. So whenever the view in the flow changes the title of the application window will change to the

--- a/tutorials/flow3/src/main/java/io/datafx/tutorial/Wizard3Controller.java
+++ b/tutorials/flow3/src/main/java/io/datafx/tutorial/Wizard3Controller.java
@@ -11,7 +11,7 @@ import io.datafx.controller.flow.action.LinkAction;
  * define the "next" button. By using the @LinkAction annotation this button will link on the next step of the
  * wizard. This annotation was already described in tutorial 2.
  *
- * When looking at the @FXMLController annotation of the class you can find a new feature. next to the fxml files that
+ * When looking at the @ViewController annotation of the class you can find a new feature. next to the fxml files that
  * defines the view of the wizard step a "title" is added. This defines the title of the view. Because the wizard is
  * added to a Stage by using the Flow.startInStage() method the title of the flow is automatically bound to the window
  * title of the Stage. So whenever the view in the flow changes the title of the application window will change to the

--- a/tutorials/flow3/src/main/java/io/datafx/tutorial/WizardDoneController.java
+++ b/tutorials/flow3/src/main/java/io/datafx/tutorial/WizardDoneController.java
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
  * controller instance were injected. So when the view appears on screen the buttons "next" and "finish" will be
  * disabled.
  *
- * When looking at the @FXMLController annotation of the class you can find a new feature. next to the fxml files that
+ * When looking at the @ViewController annotation of the class you can find a new feature. next to the fxml files that
  * defines the view of the wizard step a "title" is added. This defines the title of the view. Because the wizard is
  * added to a Stage by using the Flow.startInStage() method the title of the flow is automatically bound to the window
  * title of the Stage. So whenever the view in the flow changes the title of the application window will change to the

--- a/tutorials/flow3/src/main/java/io/datafx/tutorial/WizardStartController.java
+++ b/tutorials/flow3/src/main/java/io/datafx/tutorial/WizardStartController.java
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
  * is annotated with the  @PostConstruct annotation and therefore this method will be called once all fields of the
  * controller instance were injected. So when the view appears on screen the "back" button will be disabled.
  *
- * When looking at the @FXMLController annotation of the class you can find a new feature. next to the fxml files that
+ * When looking at the @ViewController annotation of the class you can find a new feature. next to the fxml files that
  * defines the view of the wizard step a "title" is added. This defines the title of the view. Because the wizard is
  * added to a Stage by using the Flow.startInStage() method the title of the flow is automatically bound to the window
  * title of the Stage. So whenever the view in the flow changes the title of the application window will change to the


### PR DESCRIPTION
All instances of `@FXMLController` in the documentation have been replaced with `@ViewController`, as per #6.